### PR TITLE
Update login invalid credential codes

### DIFF
--- a/BookAPI/Identity/Controllers/AuthController.cs
+++ b/BookAPI/Identity/Controllers/AuthController.cs
@@ -52,11 +52,11 @@ public class AuthController(IAuthService authService) : ControllerBase
     ///     }
     /// </remarks>
     /// <response code="200">Authentication successful.</response>
-    /// <response code="400">Invalid credentials.</response>
+    /// <response code="401">Invalid credentials.</response>
     /// <response code="500">Internal server error.</response>
     [HttpPost("login")]
     [ProducesResponseType(typeof(AuthenticationResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> LoginAsync([FromBody] LoginRequest request)
     {


### PR DESCRIPTION
## Summary
- update AuthController XML docs for failed login
- return 401 Unauthorized for invalid login attempts

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e95a4cb4832db720f38643fdd7e8