### PR TITLE
Fix CreatedAtRoute response in review creation

### DIFF
--- a/BookAPI/Controllers/ReviewController.cs
+++ b/BookAPI/Controllers/ReviewController.cs
@@ -26,11 +26,11 @@ public class ReviewController(IReviewService reviewService) : ControllerBase
     [HttpPost]
     public async Task<IActionResult> CreateReviewAsync(CreateReviewRequest request)
     {
-        var bookId = await reviewService.CreateReviewAsync(request);
+        var reviewId = await reviewService.CreateReviewAsync(request);
         return CreatedAtRoute(
             nameof(GetReviewByIdAsync),
-            new { id = bookId },
-            new { id = bookId });
+            new { reviewId },
+            new { id = reviewId });
     }
 
     [HttpPut]


### PR DESCRIPTION
## Summary
- name reviewId variable correctly when creating reviews
- return response via CreatedAtRoute using reviewId

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb9725cc832da325e32a12cc9035