### PR TITLE
Add delete review endpoint

### DIFF
--- a/BookAPI/Controllers/ReviewController.cs
+++ b/BookAPI/Controllers/ReviewController.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+
 namespace BookAPI.Controllers;
 
 [ApiController]
@@ -37,6 +39,30 @@ public class ReviewController(IReviewService reviewService) : ControllerBase
     public async Task<IActionResult> UpdateReviewAsync(UpdateReviewRequest request)
     {
         await reviewService.UpdateReviewAsync(request);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes a review by its unique ID.
+    /// </summary>
+    /// <param name="id">The ID of the review to delete.</param>
+    /// <returns>No content if the review was deleted successfully.</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     DELETE /api/review/3fa85f64-5717-4562-b3fc-2c963f66afa6
+    /// </remarks>
+    /// <response code="204">Review deleted successfully</response>
+    /// <response code="404">Review not found</response>
+    /// <response code="500">Internal server error</response>
+    [Authorize]
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError, "application/problem+json")]
+    public async Task<IActionResult> DeleteReviewAsync(Guid id)
+    {
+        await reviewService.DeleteReviewAsync(id);
         return NoContent();
     }
 }


### PR DESCRIPTION
## Summary
- add `DeleteReviewAsync` endpoint to `ReviewController`
- secure the endpoint with `[Authorize]`
- document the endpoint for Swagger

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eddcd9ec832da82bc4d4fbd416aa