### PR TITLE
Add auth requirement for review endpoints

### DIFF
--- a/BookAPI/Controllers/ReviewController.cs
+++ b/BookAPI/Controllers/ReviewController.cs
@@ -25,6 +25,7 @@ public class ReviewController(IReviewService reviewService) : ControllerBase
         return Ok(result);
     }
 
+    [Authorize]
     [HttpPost]
     public async Task<IActionResult> CreateReviewAsync(CreateReviewRequest request)
     {
@@ -35,6 +36,7 @@ public class ReviewController(IReviewService reviewService) : ControllerBase
             new { id = reviewId });
     }
 
+    [Authorize]
     [HttpPut]
     public async Task<IActionResult> UpdateReviewAsync(UpdateReviewRequest request)
     {

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ dotnet test
 
 ## 🔐 Authentication
 
-JWT-based authentication is enabled. After registering via `/api/auth/register`, you can log in at `/api/auth/login` to receive a token.  
+JWT-based authentication is enabled. After registering via `/api/auth/register`, you can log in at `/api/auth/login` to receive a token.
 Include the token in requests:
 
 ```http
 Authorization: Bearer {token}
 ```
+
+Creating, updating, or deleting books and reviews requires authentication.
 
 ---
 


### PR DESCRIPTION
## Summary
- protect CreateReviewAsync and UpdateReviewAsync with `[Authorize]`
- document that book and review mutations require a bearer token

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef682d84832d87a74ab4f3e22d8a