### PR TITLE
Add optional linkage between User and AuthUser

### DIFF
--- a/BookAPI/Identity/Configurations/AuthUserConfiguration.cs
+++ b/BookAPI/Identity/Configurations/AuthUserConfiguration.cs
@@ -35,5 +35,10 @@ public class AuthUserConfiguration : IEntityTypeConfiguration<AuthUser>
         builder.Property(u => u.UpdatedDateTime)
             .IsRequired();
 
+        builder.HasOne(au => au.User)
+            .WithOne(u => u.AuthUser)
+            .HasForeignKey<User>(u => u.AuthUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
     }
 }

--- a/BookAPI/Identity/Models/AuthUser.cs
+++ b/BookAPI/Identity/Models/AuthUser.cs
@@ -1,3 +1,5 @@
+using BookAPI.Infrastructure.Models;
+
 namespace BookAPI.Identity.Models;
 
 public class AuthUser
@@ -10,4 +12,6 @@ public class AuthUser
 
     public DateTime CreatedDateTime { get; set; }
     public DateTime UpdatedDateTime { get; set; }
+
+    public User? User { get; set; }
 }

--- a/BookAPI/Infrastructure/Configurations/UserConfiguration.cs
+++ b/BookAPI/Infrastructure/Configurations/UserConfiguration.cs
@@ -1,3 +1,5 @@
+using BookAPI.Identity.Models;
+
 namespace BookAPI.Infrastructure.Configurations;
 
 public class UserConfiguration : IEntityTypeConfiguration<User>
@@ -14,12 +16,21 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.Property(u => u.IsVerified)
             .IsRequired();
-        
+
+        builder.Property(u => u.AuthUserId)
+            .IsRequired(false);
+
         builder.HasMany(u => u.Reviews)
             .WithOne(r => r.User)
             .HasForeignKey(r => r.UserId)
             .OnDelete(DeleteBehavior.Restrict);
 
+        builder.HasOne(u => u.AuthUser)
+            .WithOne(au => au.User)
+            .HasForeignKey<User>(u => u.AuthUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         builder.HasIndex(u => u.UserName).IsUnique();
+        builder.HasIndex(u => u.AuthUserId).IsUnique();
     }
 }

--- a/BookAPI/Infrastructure/Models/User.cs
+++ b/BookAPI/Infrastructure/Models/User.cs
@@ -1,3 +1,5 @@
+using BookAPI.Identity.Models;
+
 namespace BookAPI.Infrastructure.Models;
 
 public class User
@@ -5,6 +7,9 @@ public class User
     public Guid Id { get; set; }
     public string UserName { get; set; } = null!;
     public bool IsVerified { get; set; }
+
+    public Guid? AuthUserId { get; set; }
+    public AuthUser? AuthUser { get; set; }
 
     public ICollection<Review> Reviews { get; set; } = new List<Review>();
 }


### PR DESCRIPTION
## Summary
- add `AuthUserId` and navigation properties for linking users
- configure EF relationship between `User` and `AuthUser`
- **remove generated migration files**

## Testing
- `dotnet ef migrations add LinkAuthUserToUser --project BookAPI/BookAPI.csproj --startup-project BookAPI/BookAPI.csproj` *(fails: dotnet not found)*
- `dotnet test` *(fails: dotnet not found)*


------
https://chatgpt.com/codex/tasks/task_e_684b28530dac832da6f05fec007c4b9a